### PR TITLE
pagination fix

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -854,8 +854,8 @@ CriteriaProcessor.prototype.sort = function(options) {
     self.queryString += utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(key, self.escapeCharacter) + ' ' + direction + ', ';
   });
 
-  // Remove trailing comma
-  this.queryString = this.queryString.slice(0, -2);
+  // Adding ROWNUM so that pagination works properly for repeated values in a sorted column:
+  this.queryString += ' ROWNUM ';
 };
 
 /**


### PR DESCRIPTION
Adding ROWNUM so that pagination works properly for repeated values in the sorted column.
Remove trailing comma no longer needed with this addition.

To clarify, without this fix, when sorting larger tables by a column with many repeated values (or null values also) the paging breaks in such a way that it keeps returning the same page repeatedly until a page where the sorted column starts having some different values.

It is weird and it baffled us for a bit when we saw it...